### PR TITLE
fix(): return `scanner.Err()` instead of nil

### DIFF
--- a/pkg/sum/sum.go
+++ b/pkg/sum/sum.go
@@ -204,7 +204,7 @@ func Sum5(fileName string) (ret int64, err error) {
 
 		ret += num
 	}
-	return ret, nil
+	return ret, scanner.Err()
 }
 
 func Sum5_line(fileName string) (ret int64, err error) {


### PR DESCRIPTION
The code description in the book does not match the example in github.

chapter: 10
example: 10-7

link: https://learning.oreilly.com/library/view/efficient-go/9781098105709/ch10.html#:-:text=standard%20library%E2%80%94the,for%20scanner.Scan